### PR TITLE
[4주차] 정한울

### DIFF
--- a/JeongHanUl/week4/boj_14889.java
+++ b/JeongHanUl/week4/boj_14889.java
@@ -1,0 +1,63 @@
+package nestnet_algorithm_2023_2.JeongHanUl.week4;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.StringTokenizer;
+
+public class boj_14889 {
+    //public class Main {
+    static int n;
+    static int min = Integer.MAX_VALUE;
+    static boolean[] team; // ture 팀과 false 팀으로 나눔
+    static int[][] status; // 시너지 능력치
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader bufferedReader = new BufferedReader(new InputStreamReader(System.in));
+        n = Integer.parseInt(bufferedReader.readLine());
+        team = new boolean[n];
+        StringTokenizer stringTokenizer;
+
+        status = new int[n][n];
+        for (int i = 0; i < n; i++) {
+            stringTokenizer = new StringTokenizer(bufferedReader.readLine(), " ");
+            for (int j = 0; j < n; j++) {
+                status[i][j] = Integer.parseInt(stringTokenizer.nextToken());
+            }
+        }
+
+        combination(n / 2, 0);
+
+        System.out.println(min);
+    }
+
+    public static void combination(int r, int startIndex) { // 조합을 통해 팀을 구성
+        if (r == 0) { // 종료 조건. 팀을 다 나눔
+            compareTeam();
+            return;
+        }
+
+        for (int i = startIndex; i <= n - r; i++) { // n - r 번째에선 뽑아야 됨
+            team[i] = true;
+            combination(r - 1, i + 1);
+            team[i] = false;
+        }
+    }
+    public static void compareTeam() { // 나눈 팀을 바탕으로 팀 능력치 계산하여 비교
+        int trueSum = 0, falseSum = 0;
+
+        for (int i = 0; i < n; i++) {
+            for (int j = 0; j < n; j++) {
+                if (team[i] && team[j]) {
+                    trueSum += status[i][j];
+                } else if (!team[i] && !team[j]) {
+                    falseSum += status[i][j];
+                }
+            }
+        }
+
+        if (Math.abs(trueSum - falseSum) < min) {
+            min = Math.abs(trueSum - falseSum);
+        }
+    }
+}

--- a/JeongHanUl/week4/boj_16637.java
+++ b/JeongHanUl/week4/boj_16637.java
@@ -1,0 +1,112 @@
+package nestnet_algorithm_2023_2.JeongHanUl.week4;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+
+public class boj_16637 {
+    //public class Main {
+    static int n;
+    static int max = Integer.MIN_VALUE;
+    static int[] num; // 입력 받은 정수
+    static boolean[] bracket; // 괄호의 위치 표시. 괄호가 잇는 곳 true
+    static char[] operator; // 입력 받은 연산자
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader bufferedReader = new BufferedReader(new InputStreamReader(System.in));
+        n = Integer.parseInt(bufferedReader.readLine());
+        String str = bufferedReader.readLine();
+
+        num = new int[n / 2 + 1];
+        bracket = new boolean[n / 2 + 1];
+        for (int i = 0; i < n / 2 + 1; i++) {
+            num[i] = Character.getNumericValue(str.charAt(i * 2));
+        }
+
+        operator = new char[n / 2];
+        for (int i = 0; i < n / 2; i++) {
+            operator[i] = str.charAt(i * 2 + 1);
+        }
+
+        for (int i = 0; i < n / 2 + 1; i += 2) {
+            dfs(i, 0);
+        }
+
+        System.out.println(max);
+    }
+
+    public static void dfs(int bracketNum, int index) { // 남아 있는 괄호 갯수, 분배할 때 시작 index
+        if (bracketNum == 0) { // 재귀 종료 조건. 괄호 분배가 끝남
+            ArrayList<Integer> arrayList = new ArrayList<>(); // 괄호 내의 값을 모두 계산한 이후 값들
+            boolean[] usedOperator = new boolean[n / 2]; // 사용한 연산자. 사용했으면 ture
+
+
+            for (int i = 0; i < n / 2 + 1; i++) {
+                if (!bracket[i]) {
+                    arrayList.add(num[i]);
+                } else {
+                    int result = num[i++];
+
+                    while (true) { // 괄호 내 값 계산
+                        switch (operator[i - 1]) {
+                            case '+':
+                                result += num[i];
+                                break;
+                            case '-':
+                                result -= num[i];
+                                break;
+                            case '*':
+                                result *= num[i];
+                                break;
+                        }
+                        usedOperator[i - 1] = true; // 연산자 사용 표시
+
+                        if (bracket[i]) { // 닫는 괄호
+                            arrayList.add(result);
+                            break;
+                        }
+
+                        i++;
+                    }
+                }
+            }
+
+            int result = arrayList.get(0);
+            arrayList.remove(0);
+            for (int i = 0; i < n / 2; i++) { // 리스트에 남아 있는 값 전체 연산
+                if (!usedOperator[i]) {
+                    switch (operator[i]) {
+                        case '+':
+                            result += arrayList.get(0);
+                            break;
+                        case '-':
+                            result -= arrayList.get(0);
+                            break;
+                        case '*':
+                            result *= arrayList.get(0);
+                            break;
+                    }
+                    arrayList.remove(0);
+                    usedOperator[i] = true; // 연산자 사용 표시
+                }
+            }
+
+            if (result > max) {
+                max = result;
+            }
+            return;
+        }
+        if (index > n / 2 + 1) { // 종료 조건. 시작 index가 범위를 벗어남. 배열을 다 돌았지만 괄호가 남음
+            return;
+        }
+
+        for (int i = index; i < n / 2; i++) { // 괄호 분배
+            bracket[i] = true;
+            bracket[i + 1] = true;
+            dfs(bracketNum - 2, i + 2);
+            bracket[i] = false;
+            bracket[i + 1] = false;
+        }
+    }
+}

--- a/JeongHanUl/week4/boj_1912.java
+++ b/JeongHanUl/week4/boj_1912.java
@@ -1,0 +1,36 @@
+package nestnet_algorithm_2023_2.JeongHanUl.week4;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.StringTokenizer;
+
+public class boj_1912 {
+    //public class Main {
+    static int n;
+    static int max = Integer.MIN_VALUE;
+    static int[] arr;
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader bufferedReader = new BufferedReader(new InputStreamReader(System.in));
+        n = Integer.parseInt(bufferedReader.readLine());
+        arr = new int[n];
+        StringTokenizer stringTokenizer = new StringTokenizer(bufferedReader.readLine(), " ");
+        for (int i = 0; i < n; i++) {
+            arr[i] = Integer.parseInt(stringTokenizer.nextToken());
+        }
+
+        max = arr[0];
+
+        for (int i = 1; i < n; i++) { // 배열의 값과 누적합의 값을 비교하여 택1
+            if (arr[i - 1] + arr[i] > arr[i]) {
+                arr[i] += arr[i - 1];
+            }
+            if (arr[i] > max) {
+                max = arr[i];
+            }
+        }
+
+        System.out.println(max);
+    }
+}


### PR DESCRIPTION
### **<2529_부등호>**
- 이전에 풀었어서 패스.

### **<16637_괄호 추가하기>**
- dfs를 통해 괄호의 자리를 선택하고 완료되면 숫자들을 리스트에 넣음. 이때 괄호를 만나면 연산을 하고 넣음. 리스트에 다 넣으면 리스트를 연산. 
- 간단히 보면 조합으로 괄호의 자리를 정하고 연산해준 것. 연산 우선 순위를 생각하여 2번의 계산을 걸침.

### **<14889_스타트와 링크>**
- n C n/2. 조합으로 먼저 팀을 짜고 나눈 팀의 능력치 합을 비교함.
- boolean 배열을 활용해 true 팀, false 팀으로 나누어 판단. 
- 조합을 생각한다면 어렵지 않은 문제.

### **<1912_연속합>**
- 배열의 값과 이전까지의 누적합을 비교하여 더 큰 값을 배열에 저장. max와 비교하여 swap.
- 처음엔 합을 시작할 index를 정해서 끝까지 더하며 계속 max와 비교함. 하지만 시간초과. 역시 시간복잡도가 n^2이면 대부분은 시간 초과. dp를 활용할 것.