### PR TITLE
[4주차] 허원일

### DIFF
--- a/HeoWonIl/week_4/Boj14889.py
+++ b/HeoWonIl/week_4/Boj14889.py
@@ -1,0 +1,33 @@
+import sys
+input = sys.stdin.readline
+
+n = int(input())
+chemi_board = [list(map(int, input().split())) for _ in range(n)]
+check = [0] * n
+INF = 10e9
+ans = INF
+
+
+def dfs(mem_cnt, idx):
+    global ans
+    if mem_cnt == n // 2:
+        start_chemi_sum = 0
+        link_chemi_sum = 0
+        for i in range(n):
+            for j in range(n):
+                if check[i] and check[j]:
+                    start_chemi_sum += chemi_board[i][j]
+                elif not check[i] and not check[j]:
+                    link_chemi_sum += chemi_board[i][j]
+        ans = min(ans, abs(start_chemi_sum - link_chemi_sum))
+        return
+    else:
+        for i in range(idx, n):
+            if not check[i]:
+                check[i] = 1
+                dfs(mem_cnt + 1, i + 1)
+                check[i] = 0
+
+
+dfs(0, 0)
+print(ans)

--- a/HeoWonIl/week_4/Boj16637.py
+++ b/HeoWonIl/week_4/Boj16637.py
@@ -1,0 +1,24 @@
+n = int(input())
+seq = input()
+ans = -10e9
+
+def calc_two_operand(num1, oper, num2):
+    if oper == '+':
+        return num1 + num2
+    if oper == '-':
+        return num1 - num2
+    if oper == '*':
+        return num1 * num2
+
+def dfs(i, value):
+    global ans
+    if i == n - 1:
+        ans = max(ans, value)
+        return
+    if i + 2 < n:
+        dfs(i + 2, calc_two_operand(value, seq[i + 1], int(seq[i + 2])))
+    if i + 4 < n:
+        dfs(i + 4, calc_two_operand(value, seq[i + 1], calc_two_operand(int(seq[i + 2]), seq[i + 3], int(seq[i + 4]))))
+
+dfs(0, int(seq[0]))
+print(ans)

--- a/HeoWonIl/week_4/Boj1912.py
+++ b/HeoWonIl/week_4/Boj1912.py
@@ -1,0 +1,9 @@
+n = int(input())
+dp = list(map(int, input().split()))
+ans = -10e9
+
+for i in range(1, n):
+    if dp[i] + dp[i-1] > dp[i]:
+        dp[i] = dp[i] + dp[i-1]
+        
+print(max(dp))

--- a/HeoWonIl/week_4/Boj2528.py
+++ b/HeoWonIl/week_4/Boj2528.py
@@ -1,0 +1,21 @@
+from itertools import permutations
+
+n = int(input())
+inequal_seq = list(input().split())
+avail_ans = []
+        
+for permutation in permutations(list(range(10)), n+1):
+    for i in range(1, len(permutation)):
+        if inequal_seq[i-1] == '<':
+            if permutation[i-1] > permutation[i]:
+                break
+        else:
+            if permutation[i-1] < permutation[i]:
+                break
+    else:
+        avail_ans.append(permutation)
+        min_ans = ''.join(map(str, permutation))
+        
+print(''.join(map(str, avail_ans[-1])))    
+print(''.join(map(str, avail_ans[0])))    
+


### PR DESCRIPTION
# 부등호(2529)
`min_ans = ''.join(map(str, permutation))` 라인 삭제 => 잘못 쓴 코드
## 접근 
부등호는 고정돼있고 숫자를 집어넣어야 하는데, 숫자를 일정한 규칙에 따라 집어넣는건 쉽지 않음. 따라서 나열하는 경우의 수를 모두 고려하여 각각의 경우마다 탐색함. 이 때, 부등호를 만족하지 못하면 `break` 함.  순열은 크기순을 나열을 보장하므로 후보 순열 중 마지막 원소, 첫 원소를 순서대로 출력함.
### 구현
파이썬 내장 모듈 `itertools`에서 `permutation` 함수를 활용하여 경우의 수를 순열로 찾아냄. 이후, 각각의 순열에 대해 탐색을 수행함. 

# 괄호 추가하기(16637)
## 접근
피연산자가 네 개인 경우로 생각하면 다음과 같음.
![image](https://github.com/Nestnet-study/nestnet_algorithm_2023_2/assets/70367717/0110cbbd-d5ed-4332-8184-89948020b384)
![image](https://github.com/Nestnet-study/nestnet_algorithm_2023_2/assets/70367717/e624269a-a550-4fdc-966b-5e374308993e)
백트래킹을 사용하여 풀이할 수 있음. 연산자 우선순위가 무시되므로 2, 3은 동일한 경우임. 따라서 나올 수 있는 경우는 1, 2(3), 4 의 세 가지 경우임. 
- 종료조건 : 마지막 인덱스인 경우
- 인덱스를 2 증가시켜 dfs에 대입 : 앞의 두 피연산자를 묶어주는 경우  
- 인덱스를 4 증가시켜 dfs에 대입 : 뒤의 두 피연산자를 묶어주는 경우(앞의 계산이 어떤 과정으로 이루어진지와 상관없이 앞의 계산 결과와 연산)

# 스타트와 링크(14889)
## 접근
백트래킹을 사용하여 풀이할 수 있음.
- 종료조건 : 사람들 중 절반을 탐색한 경우 => 체크가 된 사람들끼리 합을 계산, 체크가 안된 사람들끼리 합을 계산
- 탐색하면 체크 표시 : 체크를 하고 dfs를 돌린 후 체크를 풀어줌. 
=> 결국 절반을 뽑는 조합을 찾고 계산하는 과정을 반복함.

# 연속합(1912)
## 접근
정답률을 보니 단순 완전탐색은 아닐 것이고, 분류를 결국 확인 => DP 보텀업 방식 풀이에서 가장 중요한 점을 항상 명심하자. '먼저 점화식을 세워라.' 
`dp[i] = dp[i] + dp[i-1]` (dp: 해당 인덱스 번째의 원소가 연속수열의 마지막 원소일때의 연속합의 최댓값)
=> '연속된' 수열이므로 한 수열에서 다음 탐색할 원소를 더하느냐 마느냐가 핵심임. 
dp 중 최댓값이 정답임.