### PR TITLE
[5주차] 정한울

### DIFF
--- a/JeongHanUl/week5/boj_10026.java
+++ b/JeongHanUl/week5/boj_10026.java
@@ -1,0 +1,72 @@
+package nestnet_algorithm_2023_2.JeongHanUl.week5;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+
+public class boj_10026 {
+    //public class Main {
+    static int[] dr = {-1, 1, 0, 0};
+    static int[] dc = {0, 0, -1, 1};
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        int n = Integer.parseInt(br.readLine());
+        char[][] falseMap = new char[n][n]; // 적록색약이 아닌 사람이 보는 그림
+        char[][] trueMap = new char[n][n]; // 적록색약인 사람이 보는 그림. 녹색을 적색으로 입력
+
+        for (int i = 0; i < n; i++) {
+            String str = br.readLine();
+            for (int j = 0; j < n; j++) {
+                falseMap[i][j] = str.charAt(j);
+                trueMap[i][j] = (str.charAt(j) == 'G' ? 'R' : str.charAt(j)); // 녹색이면 적색으로 입력
+            }
+        }
+
+        int falseCnt = 0; // 색약이 아닌 사람이 보는 구역 개수 카운트
+        int tureCnt = 0; // 색약인 사람이 보는 구역 개수 카운트
+        boolean[][] falseVisited = new boolean[n][n]; // 방문 확인
+        boolean[][] trueVisited = new boolean[n][n]; // 방문 확인
+
+        // 색약이 아닌 사람이 보는 map을 돌며 방문하지 않은 지점에서 dfs. dfs가 끝나면 cnt++
+        for (int i = 0; i < n; i++) {
+            for (int j = 0; j < n; j++) {
+                if (!falseVisited[i][j]) {
+                    dfs(n, falseMap, falseVisited, falseMap[i][j], i, j);
+                    falseCnt++;
+                }
+            }
+        }
+
+        // 색약인 사람이 보는 map을 돌며 방문하지 않은 지점에서 dfs. dfs가 끝나면 cnt++
+        for (int i = 0; i < n; i++) {
+            for (int j = 0; j < n; j++) {
+                if (!trueVisited[i][j]) {
+                    dfs(n, trueMap, trueVisited, trueMap[i][j], i, j);
+                    tureCnt++;
+                }
+            }
+        }
+
+        System.out.println(falseCnt + " " + tureCnt);
+    }
+
+    //map: 그림이 저장되어 있는 map, visited: 방문 배열, color: 이웃한 색과 같은지 비교할 현재 자리의 색
+    static void dfs(int n, char[][] map, boolean[][] visited, char color, int row, int col) {
+        visited[row][col] = true; // 방문 표시
+
+        // 상하좌우 순으로 이동
+        for (int i = 0; i < 4; i++) {
+            int r = row + dr[i];
+            int c = col + dc[i];
+
+            if (isRange(n, r, c) && !visited[r][c] && map[r][c] == color) { // 범위 내, 미방문, 이웃한 자리가 색이 같음
+                dfs(n, map, visited, color, r, c);
+            }
+        }
+    }
+
+    static boolean isRange(int n, int row, int col) { // 범위 확인
+        return row >= 0 && row < n && col >= 0 && col < n;
+    }
+}

--- a/JeongHanUl/week5/boj_1987.java
+++ b/JeongHanUl/week5/boj_1987.java
@@ -1,0 +1,63 @@
+package nestnet_algorithm_2023_2.JeongHanUl.week5;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.StringTokenizer;
+
+public class boj_1987 {
+    //public class Main {
+    static int max = 0; // 최대 칸 수를 저장
+    static int[] dr = {-1, 1, 0, 0};
+    static int[] dc = {0, 0, -1, 1};
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        int r = Integer.parseInt(st.nextToken());
+        int c = Integer.parseInt(st.nextToken());
+
+        char[][] map = new char[r][c];
+        for (int i = 0; i < r; i++) {
+            String str = br.readLine();
+            for (int j = 0; j < c; j++) {
+                map[i][j] = str.charAt(j);
+            }
+        }
+
+        //visited가 없는 이유: 같은 알파벳은 못 지나가기 때문에 alphabet 배열에 이미 포함되어 있음
+        boolean[] alphabet = new boolean[26]; // 알파벳 사용을 표시. [0]: A, [1]: B...
+
+        dfs(r, c, map, alphabet, 0, 0, 1);
+
+        System.out.println(max);
+    }
+
+    // cnt: 지나간 칸 수. max와 매번 대소비교
+    static void dfs(int r, int c, char[][] m, boolean[] a, int row, int col, int cnt) {
+        if (cnt > max) { // 지나갈 수 있는 최대의 칸 수를 저장해야 함. max보다 클 때마다 저장
+            max = cnt;
+        }
+
+        int alphaIndex = m[row][col] - 'A'; // 0번지가 'A'를 나타냄. 문자에서 'A'를 빼주면 아스키 코드로 접근 가능
+        a[alphaIndex] = true; // 알파벳 방문 표시
+
+        // 상하좌우 순으로 이동
+        for (int i = 0; i < 4; i++) {
+            int nr = row + dr[i];
+            int nc = col + dc[i];
+
+            if (isRange(r, c, nr, nc)) { // 범위 확인
+                alphaIndex = m[nr][nc] - 'A';
+                if (!a[alphaIndex]) { // 미방문한 알파벳이면
+                    dfs(r, c, m, a, nr, nc, cnt + 1);
+                    a[alphaIndex] = false;
+                }
+            }
+        }
+    }
+
+    static boolean isRange(int r, int c, int row, int col) { // 범위 확인
+        return row >= 0 && row < r && col >= 0 && col < c;
+    }
+}

--- a/JeongHanUl/week5/boj_2667.java
+++ b/JeongHanUl/week5/boj_2667.java
@@ -1,0 +1,75 @@
+package nestnet_algorithm_2023_2.JeongHanUl.week5;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.Collections;
+
+public class boj_2667 {
+    //public class Main {
+    static int n;
+    static int cnt; // 이웃한 집 카운트
+    static int[] dr = {-1, 1, 0, 0};
+    static int[] dc = {0, 0, -1, 1};
+    static boolean[][] visited; // 방문 체크
+    static int[][] map;
+
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        n = Integer.parseInt(br.readLine());
+        visited = new boolean[n][n];
+        map = new int[n][n];
+        ArrayList<Integer> arrayList = new ArrayList<>(); // 각 단지에 속하는 집의 수를 넣을 리스트
+
+        for (int i = 0; i < n; i++) {
+            String str = br.readLine();
+            for (int j = 0; j < n; j++) {
+                map[i][j] = Character.getNumericValue(str.charAt(j));
+            }
+        }
+
+        // 방문하지 않은 배열 중 집인 경우는 dfs, 아닌 경우는 방문
+        for (int i = 0; i < n; i++) {
+            for (int j = 0; j < n; j++) {
+                if (!visited[i][j]) {
+                    if (map[i][j] == 1) {
+                        cnt = 1; // cnt 초기화 및 최초 방문하는 집 카운트
+                        dfs(i, j);
+                        arrayList.add(cnt); // dfs가 종료된 시점의 cnt를 리스트에 add
+                    } else {
+                        visited[i][j] = true;
+                    }
+                }
+            }
+        }
+
+        Collections.sort(arrayList);
+        int size = arrayList.size();
+        System.out.println(size);
+        for (int i = 0; i < size; i++) {
+            System.out.println(arrayList.get(0));
+            arrayList.remove(0);
+        }
+    }
+
+    public static void dfs(int row, int col) {
+        visited[row][col] = true; // 방문 체크
+
+        // 상 하 좌 우 방문
+        for (int i = 0; i < 4; i++) {
+            int r = row + dr[i];
+            int c = col + dc[i];
+
+            if (isRange(r, c) && !visited[r][c] && map[r][c] == 1) { // 범위에 들고, 방문하지 않았고, 집인 경우
+                cnt++; // 집 갯수 카운트
+                dfs(r, c);
+            }
+        }
+    }
+
+    public static boolean isRange(int row, int col) { // 행과 열 범위 확인
+        return row < n && row >= 0 && col < n && col >= 0;
+    }
+}


### PR DESCRIPTION
## <2667_단지번호붙이기>
- 완전 탐색에서의 dfs는 익숙했으나 그래프 관련 dfs는 아직 미숙함. 공부가 필요하다고 판단되어 답을 찾아봄.
- n * n 지도를 전체 돌면서 미방문한 곳 and 집이 위치한 곳에선 dfs를 통해 인접한 집 카운트. dfs가 끝나면 총 단지 수++.
- 오름차순 정렬 또한 필요하기 때문에 리스트에 다 들어가면 정렬.
- 인접한 집을 카운트하는 과정에서 중복 카운트를 우려함. 하지만 방문한 곳은 다시 방문하지 않기 때문에 결국 dfs는 정확히 인접 집의 수만큼 호출. 이걸 이해하는 데에  시간이 걸림.
***
## <10026_적록색약>
- 이 문제부터 재귀함수일 때 전역변수 사용을 지양하고 매개변수를 사용함.
- 이전 문제와 매우 유사. 같은 구역 나누기 문제.
- n * n 그림을 전체 돌면서 미방문한 곳에선 dfs를 통해 인접한 같은 색에 방문.
- 색약인 사람과 아닌 사람이 보는 그림을 나누어 생각(구역 카운트, visited 배열도 마찬가지). 색약인 사람이 보는 그림은 'G'를 'R'로.
- 코드에선 이중 for문이 두 번 돌아가지만 하나로 합칠 수 있을 것 같음.
***
## <1987_알파벳>
- 길찾기 문제라고 할 수 있는지 모르겠지만 그런 유형이라고 느낌.
- 0, 0에서 시작하여 dfs를 통해 이동 칸 수의 최댓값을 구함. 가는 방향에 따라 결과가 달라지기 때문에 백트래킹 필요.
- 같은 알파벳은 지나가지 못하기 때문에 visited 대신 알파벳 flag 배열만 사용.
- 이전 두 문제와는 조금 다른 유형. 그새 익숙해졌는지 백트래킹을 생각하지 못해 시간이 조금 걸림. 같은 dfs라도 유형을 나누는 것이 중요.
***
## 번외
- 재귀함수에서 전역변수를 사용하는 것과 매개변수를 사용하는 것의 차이가 궁금해짐.
- 전역변수를 사용하면 성능(실행 시간, 메모리 공간)을 향상시킬 순 있으나 공동 개발 환경에선 오류가 발생할 수 있고 디버그가 어려움.
- 참고: https://jaehoney.tistory.com/75