### PR TITLE
[5주차] 허원일

### DIFF
--- a/HeoWonIl/week_5/Boj10026.py
+++ b/HeoWonIl/week_5/Boj10026.py
@@ -1,0 +1,42 @@
+import sys
+
+sys.setrecursionlimit(10 ** 6)
+input = sys.stdin.readline
+n = int(input())
+color_board = [list(input().rstrip()) for _ in range(n)]
+check = [[0] * n for _ in range(n)]
+check_RG_blindness = [[0] * n for _ in range(n)]
+area_cnt = 0
+area_cnt_RG_blindness = 0
+
+dx = [-1, 0, 1, 0]
+dy = [0, 1, 0, -1]
+
+def dfs(x, y, prev_color, RG_BLINDNESS):
+    for i in range(4):
+        nx = x + dx[i]
+        ny = y + dy[i]
+        if 0 <= nx < n and 0 <= ny < n:
+            if RG_BLINDNESS:
+                if (check_RG_blindness[nx][ny] == 0) and (color_board[nx][ny] == prev_color or (color_board[nx][ny] == 'R' and prev_color == 'G') or (color_board[nx][ny] == 'G' and prev_color == 'R')):
+                    check_RG_blindness[nx][ny] = 1
+                    dfs(nx, ny, color_board[nx][ny], True)
+            else:
+                if check[nx][ny] == 0 and color_board[nx][ny] == prev_color:
+                    check[nx][ny] = 1
+                    dfs(nx, ny, color_board[nx][ny], False)
+
+for i in range(n):                    
+    for j in range(n):  
+        if check[i][j] == 0:
+            area_cnt += 1
+            check[i][j] = 1
+            dfs(i, j, color_board[i][j], False)
+        if check_RG_blindness[i][j] == 0:
+            area_cnt_RG_blindness += 1
+            check_RG_blindness[i][j] = 1
+            dfs(i, j, color_board[i][j], True)
+
+print(area_cnt, area_cnt_RG_blindness)
+            
+    

--- a/HeoWonIl/week_5/Boj1987.py
+++ b/HeoWonIl/week_5/Boj1987.py
@@ -1,0 +1,52 @@
+# set 풀이
+import sys
+input = sys.stdin.readline
+
+R, C = map(int, input().split())
+alph_board = [list(input().rstrip()) for _ in range(R)]
+check = set(alph_board[0][0])
+ans = 1
+
+dx = [-1, 0, 1, 0]
+dy = [0, 1, 0, -1]
+
+def dfs(x, y, cnt):
+    global ans
+    ans = max(ans, cnt)
+    for i in range(4):
+        nx = x + dx[i]
+        ny = y + dy[i]
+        if 0 <= nx < R and 0 <= ny < C:
+            if alph_board[nx][ny] not in check:
+                check.add(alph_board[nx][ny])
+                dfs(nx, ny, cnt + 1)
+                check.remove(alph_board[nx][ny])
+
+dfs(0, 0, ans)
+print(ans)
+
+# ascill 코드 풀이
+R, C = map(int, input().split())
+alph_board = [list(input()) for _ in range(R)]
+check = [0] * 26
+ans = 1
+
+dx = [-1, 0, 1, 0]
+dy = [0, 1, 0, -1]
+
+def dfs(x, y, cnt):
+    global ans
+    ans = max(ans, cnt)
+    for i in range(4):
+        nx = x + dx[i]
+        ny = y + dy[i]
+        if 0 <= nx < R and 0 <= ny < C:
+            index = ord(alph_board[nx][ny]) - 65
+            if check[index] == 0:
+                check[index] = 1
+                dfs(nx, ny, cnt + 1)
+                check[index] = 0
+
+check[ord(alph_board[0][0]) - 65] = 1
+dfs(0, 0, ans)
+print(ans)

--- a/HeoWonIl/week_5/Boj2667.py
+++ b/HeoWonIl/week_5/Boj2667.py
@@ -1,0 +1,30 @@
+n = int(input())
+complex_board = [list(map(int, input())) for _ in range(n)]
+complex_cnt_list = []
+
+dx = [-1, 0, 1, 0]
+dy = [0, 1, 0, -1]
+
+def dfs(x, y):
+    global apart_cnt
+    for i in range(4):
+        nx = x + dx[i]
+        ny = y + dy[i]
+        if 0 <= nx < n and 0 <= ny < n:
+            if complex_board[nx][ny] == 1:
+                complex_board[nx][ny] = -1
+                dfs(nx, ny)
+                apart_cnt += 1
+
+for i in range(n):
+    for j in range(n):
+        if complex_board[i][j] == 1:
+            apart_cnt = 1
+            complex_board[i][j] = -1
+            dfs(i, j)
+            complex_cnt_list.append(apart_cnt)
+
+print(len(complex_cnt_list))
+complex_cnt_list.sort()
+for complex_cnt in complex_cnt_list:
+    print(complex_cnt)        


### PR DESCRIPTION
# 단지번호 붙이기(2667)
### 구현
2차원 리스트를 돌며(이중 for문을 돌며) 아파트가 있는 순간(1인 순간) dfs 탐색을 시작하고 해당 아파트를 포함하여 상하좌우에 맞붙어있는 아파트들을 체크한다. (-1로 변환) 이 과정을 반복하며 매 탐색시마다 세준 카운트를 미리 만들어준 리스트에 넣어준다.
# 알파벳(1987)
## 접근
제일 어려웠던 점이 매번 check를 어떻게 설정하고 초기화하는지였다. set()를 사용하면 좋겠다고는 생각했지만 이를 check 배열로써 사용할 수 있는 것까지 생각이 도달하지 못했다. 또한 인자로 카운트값을 계속하여 전달할 수 있다는 것을 상기했다. dfs의 '후처리'와 '인자로 인덱스 전달'을 다시 한 번 복습했다.
### 구현
set()로 중복을 제외하여 check 역할을 하는 일종의 체크목록을 만들어준다. 당연히 dfs 탐색이 끝난 후에는 체크를 해제해준다. 또한 조건 만족시 카운트 값을 증가하는 로직을 dfs()의 인자로 전달하는 방식으로 구현한다.
# 적록색약(10026)
## 접근
고민 끝에 dfs 인자로써 이전에 탐색 색상과 적록색약 여부를 전달할 수 있다는 생각에 다다랐다. 역시 dfs의 '인자전달' 방식을 상기할 수 있었다. 
### 구현
메모리 제한에만 걸리지 않는다면 `sys.setrecursionlimit(10 ** 6)`를 사용하여 dfs 깊이를 조정할 수 있다. 이중 for문을 돌며 dfs 탐색을 통해 적록색약 유무에 따른 각 체크리스트를 갱신한다. dfs 탐색시에도 적록색약 유무에 따라 조건을 나눈다.