### PR TITLE
(#30) [7주차] 김도현

### DIFF
--- a/KimDoHyun/week7/공유기설치.py
+++ b/KimDoHyun/week7/공유기설치.py
@@ -1,0 +1,36 @@
+import sys
+input=sys.stdin.readline
+
+house_count,wifi_count=input().split()
+house_count,wifi_count=int(house_count),int(wifi_count)
+arr=[]
+for _ in range(house_count):arr.append(int(input()))
+arr.sort()
+
+def binary_search(arr,wifi_count):
+    result=0
+    left,right=0,arr[-1]
+    while left<=right:
+        distanse=(left+right)//2   
+
+        start_house=arr[0]
+        tmp_count=1
+        for i in range(1,house_count):
+            if arr[i]-start_house>=distanse:
+                tmp_count+=1
+                start_house=arr[i]
+        if tmp_count>=wifi_count:
+            result=distanse
+            left=distanse+1
+        else:
+            right=distanse-1
+    return result
+    
+
+print(binary_search(arr,wifi_count))
+
+
+
+
+
+

--- a/KimDoHyun/week7/나무자르기.py
+++ b/KimDoHyun/week7/나무자르기.py
@@ -1,0 +1,22 @@
+n,m=map(int,input().split())
+arr=list(map(int,input().split()))
+
+result=0
+start=1
+end=max(arr)
+
+while start<=end:
+    mid=(start+end)//2
+    total=0
+    for i in arr:
+        if i-mid>0:
+            total+=i-mid
+        if total>m:
+            break
+
+    if total>=m:
+        start=mid+1
+        result=mid
+    else:
+        end=mid-1
+print(result)

--- a/KimDoHyun/week7/용액.py
+++ b/KimDoHyun/week7/용액.py
@@ -1,0 +1,24 @@
+n=int(input())
+arr=list(map(int,input().split()))
+
+
+def two_search(arr):
+    left,right=0,len(arr)-1
+    dis=2e10
+    result=[0,0]
+    while left<right:
+        value=arr[left]+arr[right]
+        if value>=0:
+            if abs(value)<dis:
+                dis=abs(value)
+                result[0],result[1]=arr[left],arr[right]
+            right-=1
+        else:
+            if abs(value)<dis:
+                dis=abs(value)
+                result[0],result[1]=arr[left],arr[right]
+            left+=1
+    return result
+
+print(*two_search(arr))
+


### PR DESCRIPTION
# 나무자르기
이분탐색 문제 중 처음으로 mid값과 target값을 비교만 하는 이분탐색의 좁은 사고를 깨준 문제이다.
이 문제에서는 total을 사옹하여 mid값을 각 arr전체 원소의 차값을 total에 계속 더해준 후 문제에서 설정된 m값 보다 커야하는 조건을 다룬다. 
m보다 크지만 m보다 크면서 가장 적은 값이 존재하기에 result에 저장해두고 계속 탐색한다.
m보다 작은 경우 성립하지 않기 때문에 end(right)값을 mid보다 작게 만들어 다시 이분탐색을 진행한다.

# 용액
이 문제는 이분탐색으로 풀이시에 해메게 되어 투포인터 탐색 방식으로 변경하여 풀이하였다.
투포인터 방식으로는 두 용액의 합이 0보다 큰 경우 right를 mid-1로 하는 것이 아닌 right 를 right-1로 한칸씩 left도 마찬가지로 좌우에서 동시 탐색하는 방식이다. 이후 대소비교를 통해 지속적으로 result값을 갱신하면 되는 문제이다.

# 공유기 설치
나무자르기 문제와 같이 total대신 for문에서 차 값이 distance보다 큰 경우를 카운트 하여 공유기 개수와 비교한다. 공유기 개수보다 많은 경우 distance가 작은 경우이기 때문에 left값을 증가시킨 후 다시 반복한다.
공유기 개수가 같거나 많은 경우가 정답이지만, 경우의 수의 최솟값이 아니기 때문에 result에 값을 저장한 후 다시 진행하여 최솟값을 찾고,
공유기 개수가 적은 경우에는 distance가 큰 경우 이기 때문에 right값을 축소 시켜서 이분탐색을 다시 진행한다.