### PR TITLE
[7주차] 허원일

### DIFF
--- a/HeoWonIl/week_7/Boj2111.py
+++ b/HeoWonIl/week_7/Boj2111.py
@@ -1,0 +1,28 @@
+n, c = map(int, input().split())
+homes = []
+for _ in range(n):
+    home = int(input())
+    homes.append(home)
+homes.sort()
+
+start = 1
+end = homes[-1] - homes[0]
+ans = 0    
+
+while start <= end:
+    mid = (start + end) // 2
+    cur = homes[0]
+    cnt = 1
+
+    for i in range(1, len(homes)):
+        if homes[i] >= cur + mid:
+            cnt += 1
+            cur = homes[i]
+
+    if cnt >= c:
+        start = mid + 1
+        ans = mid
+    else:
+        end = mid - 1
+
+print(ans)

--- a/HeoWonIl/week_7/Boj2467.py
+++ b/HeoWonIl/week_7/Boj2467.py
@@ -1,0 +1,22 @@
+n = int(input())
+solutions = list(map(int, input().split()))
+result_a, result_b = 0, 0
+prev_mix_amount = 10e9
+start = 0
+end = len(solutions) - 1
+
+while start < end:
+    solution_a, solution_b = solutions[start], solutions[end]
+    mix_amount = solution_a + solution_b
+    if mix_amount == 0:
+        result_a, result_b = solution_a, solution_b
+        break
+    elif mix_amount < 0:
+        start += 1
+    else:
+        end -= 1
+    if abs(prev_mix_amount) > abs(mix_amount):
+        result_a, result_b = solution_a, solution_b
+        prev_mix_amount = mix_amount
+
+print(result_a, result_b)

--- a/HeoWonIl/week_7/Boj2805..py
+++ b/HeoWonIl/week_7/Boj2805..py
@@ -1,0 +1,28 @@
+n, m = map(int, input().split())
+trees = list(map(int, input().split()))
+trees.sort()
+start, end = 0, trees[-1] + 1
+
+def find_lowest_cut_idx(trees, target):
+    low, high = 0, len(trees) - 1
+
+    while low <= high:
+        mid = (low + high) // 2
+        current = trees[mid]
+        if current <= target:
+            low = mid + 1
+        else:
+            high = mid - 1
+    return low
+
+while start <= end:
+    mid = (start + end) // 2
+
+    idx = find_lowest_cut_idx(trees, mid)
+    remainder = sum(trees[idx:]) - mid * (len(trees) - idx)
+    if remainder >= m:
+        start = mid + 1
+    else:
+        end = mid - 1
+        
+print(end)


### PR DESCRIPTION
# 🤔 공유기 설치 (2111)
다른 사람의 풀이를 참고하여 문제 해결방법을 터득했다. 핵심은 공유기 사이 '최소거리'를 이진탐색을 사용해 찾는 것이다. 이진탐색 종료 후 조건에 따라 '최소거리'를 줄일지 늘릴지 결정해야 한다.

__참고 풀이__
[RRCoding Velog](https://velog.io/@yoonuk/%EB%B0%B1%EC%A4%80-2110-%EA%B3%B5%EC%9C%A0%EA%B8%B0-%EC%84%A4%EC%B9%98-Python)
## 접근 ❓
집의 거리를 정렬한 상태에서 탐색이 필요하다. => 이진탐색의 조건
조건에 따라 최소거리의 재조정이 필요하다. => 이진탐색 수행
### 풀이 ✏️ 
집의 위치를 담은 배열 정렬 후, 첫 집과 마지막 집의 중간을 탐색 시작점으로 설정한다. 첫번째 집을 현재 지점으로 보고, for 반복문을 통해 현재 지점(집)과 설정한 최소거리 이상의 거리를 둔 지점(집)만을 세어준다. 카운트와 동시에 현재 지점을 해당 지점으로 초기화한다. 반복문 종료 후, 조건에 따라 최소거리를 재조정한다.

# 🤔 용액 (2467)
이분탐색을 통한 풀이는 생각해내지 못했고, 투 포인터를 사용해 합을 계산, 답을 갱신하는 방식으로 풀이하였다.
## 접근 ❓
입력은 오름차순으로 입력된다. => 이진탐색의 조건 이미 충족
조건에 따라 두 개의 혼합용액 중 하나를 교체한다. => 포인터 조정 필요
###  풀이 ✏️
오름차순으로 정렬된 용액 배열에서 첫 용액과 마지막 용액을 초기값으로 지정한다. 두 용액을 혼합한 혼합용액의 특성값이 음수라면 특성값이 더 작은용액을 교체해주어야 특성값이 0에 가까워질 것이고 반대의 경우도 같은 논리로 특성값이 더 큰 용액을 교체해주어야 할 것이다. 이진탐색 범위 조정 후에는 정답 초기화를 진행한다.

# 🤔 나무 자르기(2805)
두 개의 이진탐색(외부, 내부)을 사용하여 풀이하였지만, 다른 사람의 풀이를 확인하니 나무의 개수가 최대 백만 이하이므로 `find_lowest_cut_idx` 함수가 굳이 필요없다고 결론을 내렸다. 만약 나무의 개수가 훨씬 많다면 내 풀이가 더 효율적일지도 모르겠다. (단순 반복문으로 자를 나무를 선택해도 시간 초과나지 않을 것)
## 접근 ❓
우선 나무를 정렬해준다. => 이후 `find_lowest_cut_idx` 함수가 쓰일 수 있는 이유
자른 나무들의 총 길이 합에 따른 탐색 위치(톱의 위치) 조정한다. => 외부 이진탐색 수행 필요
탐색 위치가 고정되었을 때의 자를 수 있는 나무의 시작점(인덱스)을 찾는다. => 내부 이진탐색 수행 필요
### 풀이 ✏️ 
접근 참고






