### PR TITLE
(#35) [8주차] 김도현

### DIFF
--- a/KimDoHyun/week8/LCS2.py
+++ b/KimDoHyun/week8/LCS2.py
@@ -1,0 +1,25 @@
+string_A=list(input())
+string_B=list(input())
+len_A,len_B=len(string_A),len(string_B)
+
+i,j=0,0
+LCS=[[0 for i in range(len_B+1)] for j in range(len_A+1)]
+
+for i in range(len_A+1):
+    for j in range(len_B+1):
+        if i == 0 or j == 0:  LCS[i][j] = 0
+        elif string_A[i-1] == string_B[j-1]:LCS[i][j] = LCS[i - 1][j - 1] + 1
+        else:LCS[i][j] = max(LCS[i - 1][j], LCS[i][j - 1])
+
+result=[]
+while True:
+    if i==0 or j==0:break
+    if LCS[i][j]==LCS[i-1][j] :i=i-1  
+    elif LCS[i][j]==LCS[i][j-1] :j=j-1    
+    else:
+        result.append(string_A[i-1])
+        i,j=i-1,j-1
+    
+print(len(result))
+for i in range(len(result)-1,-1,-1):print(result[i],end="")
+

--- a/KimDoHyun/week8/스티커.py
+++ b/KimDoHyun/week8/스티커.py
@@ -1,0 +1,13 @@
+t=int(input())
+for _ in range(t):
+    n=int(input())
+    arr=[]
+    for i in range(2):arr.append(list(map(int,input().split())))
+    if n==1:
+        print(*max(arr))
+        continue
+    arr[0][1],arr[1][1]=arr[0][1]+arr[1][0],arr[1][1]+arr[0][0]
+    for i in range(2,n):
+        arr[0][i]=max(arr[1][i-1],arr[1][i-2])+arr[0][i]
+        arr[1][i]=max(arr[0][i-1],arr[0][i-2])+arr[1][i]
+    print(max(arr[0][i],arr[1][i]))

--- a/KimDoHyun/week8/이친수.py
+++ b/KimDoHyun/week8/이친수.py
@@ -1,0 +1,15 @@
+n=int(input())
+
+
+dp_0=[0]*91
+dp_1=[0]*91
+
+dp_0[1],dp_1[1]=0,1
+dp_0[2],dp_1[2]=1,0
+
+for i in range(3,n+1):
+    dp_0[i]=dp_0[i-1]+dp_1[i-1]
+    dp_1[i]=dp_0[i-1]
+
+if n<=2:print(1)
+else:print(dp_0[i]+dp_1[i])


### PR DESCRIPTION
#스티커

스티커 문제는 최댓값을 구하는 로직을 찾는것이 중요한 문제였다.
위아래 양옆이 스티커를 찢으면 다음으로 선택할 수 없게 되기 때문에, 
![스티커문제 해설](https://github.com/Nestnet-study/nestnet_algorithm_2023_2/assets/115572203/99685ca3-0bba-41c3-8466-7ebdafdddabd)
위의 사진과 같이 0번째줄의 dp의 경우 1번째줄 (i-1)자리와 (i-2)의 자리를 비교하면 되고 1번째 줄의 dp의 경우 0번째 줄의 dp와 반대로만 실행하면 모든 경우의 최댓값을 구할 수 있게 된다.


#이친수

이친수 문제의 경우 0으로 시작하지 않고 1이 2개가 연속되면 안되기 때문에 
첫 초기값은 1,0으로 고정이다.
초깃값 고정 + 점화식(규칙) 이 존재하는 경우 ->dp풀이가 가능하기 때문에
첫번째와 두번째 초기값을
dp_0[1],dp_1[1]=0,1
dp_0[2],dp_1[2]=1,0     로 초기화를 해준 뒤 

n<=2인경우 예외처리로 문제를 풀이하였다.
점화식을 구할때에는 규칙을 찾아야 하는데 규칙은 1이 2번연속나오면 안되는 경우이기에 (i-1)번째가 0인경우 i번째에 0과1이 둘다 나올 수 있고, (i-1)번째가 1인 경우 i번째 1이나올수 없고 0만 가능하다.이를 활용하여 아래와 같은 점화식을 for문으로 반복하였다.
    dp_0[i]=dp_0[i-1]+dp_1[i-1]
    dp_1[i]=dp_0[i-1]


#LCS2

LCS(Longest Common Subsequence, 최장 공통 부분 수열)의 경우, dp의 로직을 가지고 풀이하는 것은 맞지만, 
따로 알고리즘을 구성하고 있다고 봐도 무방하다.
이 부분에 대해는 설명이 미흡하므로 
https://velog.io/@emplam27/%EC%95%8C%EA%B3%A0%EB%A6%AC%EC%A6%98-%EA%B7%B8%EB%A6%BC%EC%9C%BC%EB%A1%9C-%EC%95%8C%EC%95%84%EB%B3%B4%EB%8A%94-LCS-%EC%95%8C%EA%B3%A0%EB%A6%AC%EC%A6%98-Longest-Common-Substring%EC%99%80-Longest-Common-Subsequence
위의 사이트를 참고바란다.

