### PR TITLE
[8주차] 김성호

### DIFF
--- a/KimSeongHo/week_8/Boj2193.java
+++ b/KimSeongHo/week_8/Boj2193.java
@@ -1,0 +1,25 @@
+package nestnet_algorithm_2023_2.KimSeongHo.week_8;
+
+import java.util.Scanner;
+
+// 1로 시작, 1이 두번 연속 ㄴㄴ
+public class Boj2193 {
+//public class Main {
+    public static void main(String[] args) {
+        Scanner scanner = new Scanner(System.in);
+        int n = scanner.nextInt();
+        long[] dp = new long[n + 1];
+
+        dp[1] = 1;
+        if(dp.length > 2){
+            dp[2] = 1;          // 10
+        }
+
+        // i-2번째는 1로 시작하는거, i-1번째는 0으로 시작하는거
+        for(int i = 3; i <= n; i++){
+            dp[i] = dp[i - 1] + dp[i - 2];
+        }
+
+        System.out.println(dp[n]);
+    }
+}

--- a/KimSeongHo/week_8/Boj9252.java
+++ b/KimSeongHo/week_8/Boj9252.java
@@ -1,0 +1,46 @@
+package nestnet_algorithm_2023_2.KimSeongHo.week_8;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+
+// 최장 공통 부분 수열
+public class Boj9252 {
+//public class Main {
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+
+        String s = br.readLine(), s1 = br.readLine();
+
+        int[][] dp = new int[s.length() + 1][s1.length() + 1];
+
+        for(int i = 1; i <= s.length(); i++) {
+            for(int j = 1; j <= s1.length(); j++) {
+                dp[i][j] = Math.max(dp[i - 1][j], dp[i][j - 1]);
+                if(s.charAt(i - 1) == s1.charAt(j - 1)) {
+                    dp[i][j] = Math.max(dp[i - 1][j - 1] + 1 , dp[i][j]);
+                }
+            }
+        }
+
+        String answer = "";
+        int i = dp.length - 1, j = dp[0].length - 1;
+        while(i != 0 && j != 0) {
+            if(dp[i][j] == dp[i - 1][j]) {
+                i--;
+            }
+            else if(dp[i][j] == dp[i][j - 1]) {
+                j--;
+            }
+            else {
+                answer += s.charAt(i - 1);
+                i--;
+                j--;
+            }
+        }
+        System.out.println(dp[s.length()][s1.length()]);
+        System.out.print(new StringBuilder(answer).reverse());
+    }
+
+
+}

--- a/KimSeongHo/week_8/Boj9465.java
+++ b/KimSeongHo/week_8/Boj9465.java
@@ -1,0 +1,43 @@
+package nestnet_algorithm_2023_2.KimSeongHo.week_8;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.StringTokenizer;
+
+// 최대가 되게 스티커 떼기
+public class Boj9465 {
+//public class Main {
+    public static int solution(int[][] arr){
+        if(arr[0].length > 1){
+            arr[0][1] += arr[1][0];
+            arr[1][1] += arr[0][0];
+        }
+
+        for(int i = 2; i < arr[0].length; i++){     //열
+            arr[0][i] += Math.max(arr[1][i - 1], arr[1][i - 2]);
+            arr[1][i] += Math.max(arr[0][i - 1], arr[0][i - 2]);
+        }
+
+        return Math.max(arr[0][arr[0].length - 1], arr[1][arr[0].length - 1]);
+    }
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader bufferedReader = new BufferedReader(new InputStreamReader(System.in));
+        int tCase = Integer.parseInt(bufferedReader.readLine());
+
+        while(tCase-- > 0){
+            int col = Integer.parseInt(bufferedReader.readLine());
+            int[][] arr = new int[2][col];
+
+            for(int i = 0; i < 2; i++){
+                StringTokenizer stringTokenizer = new StringTokenizer(bufferedReader.readLine());
+                for(int j = 0; j < col; j++){
+                    arr[i][j] = Integer.parseInt(stringTokenizer.nextToken());
+                }
+            }
+
+            System.out.println(solution(arr));
+        }
+    }
+}


### PR DESCRIPTION
## :grin: 2193 이친수 
완전탐색으로 찾을 수 있겠지만, 90자리의 경우를 완전탐색하면 2의90제곱이 나오기 때문에 시간초과가 날게 분명하다
-> DP로 해결<br>
![image](https://github.com/Nestnet-study/nestnet_algorithm_2023_2/assets/81570533/b846ea00-8eaa-4efc-9c54-8b9acef7bc91)
i번째에는 i-1번째에 0을 더한 경우와 i-2번째에 01을 더한 경우가 들어가면 된다. 
점화식 : dp[i] = dp[i - 1] + dp[i - 2]

## :grin: 9465 스티커
스티커를 떼는 경우의 수를 모두 구할 수 있다. 하지만, 그 경우, n이 100,000일 때, 너무 많아진다. 
--> DP로 해결 
<a href="https://velog.io/@kksshh0612/%EB%B0%B1%EC%A4%80-9465-%EC%8A%A4%ED%8B%B0%EC%BB%A4-java">자세한 내용은 여기에</a>

## :grin: 9252 LCS 2
두 글자가 모두 1000글자이면, 단순 비교만 1,000,000이 된다. 시간초과가 난다. 
--> DP로 해결 
![image](https://github.com/Nestnet-study/nestnet_algorithm_2023_2/assets/81570533/36904acc-5d2a-4b71-bcb3-95447287334a)
문제를 쪼개어 생각하면, 
1. C를 탐색할 때, A일때 0개, AC일때 1개, ACA일때 1개, ACAY일때 1개.. 
2. CA를 탐색할 때, A일때 1개, AC일때 1개, ACA일때 2개... 
이런식으로 탐색하며 공통 부분 수열의 길이를 저장한다. 
저장이 끝난 후에는, 맨 오른쪽 아래부터 시작하여 탐색하며 부분수열을 찾는다. 
너무 어려워서 보고했다.
