### PR TITLE
(#44) [겨울방학 2주차] 허원일

### DIFF
--- a/HeoWonIl/winter_2/13549.py
+++ b/HeoWonIl/winter_2/13549.py
@@ -1,0 +1,23 @@
+from collections import deque
+MAX_DIS = 100001
+
+n, k = map(int, input().split())
+q = deque()
+q.append(n)
+visited = [-1] * (MAX_DIS + 1)
+visited[n] = 0
+
+while q:
+    cur_n = q.popleft()
+    if cur_n == k:
+        print(visited[cur_n])
+        break
+    if 0 < cur_n * 2 < MAX_DIS and visited[cur_n * 2] == -1:
+        visited[cur_n * 2] = visited[cur_n]
+        q.appendleft(cur_n * 2)
+    if 0 <= cur_n - 1 < MAX_DIS and visited[cur_n - 1] == -1:
+        visited[cur_n - 1] = visited[cur_n] + 1
+        q.append(cur_n - 1)
+    if 0 <= cur_n + 1 < MAX_DIS and visited[cur_n + 1] == -1:
+        visited[cur_n + 1] = visited[cur_n] + 1
+        q.append(cur_n + 1)

--- a/HeoWonIl/winter_2/14940.py
+++ b/HeoWonIl/winter_2/14940.py
@@ -1,0 +1,41 @@
+from collections import deque
+
+n, m = map(int, input().split())
+data = [list(map(int, input().split())) for _ in range(n)]
+visited = [[-1] * m for _ in range(n)]
+
+dx = [-1, 0, 1, 0]
+dy = [0, 1, 0, -1]
+
+
+def bfs(a, b):
+    q = deque()
+    q.append((a, b))
+    visited[a][b] = 0
+    
+    while q:
+        x, y = q.popleft()
+        for i in range(4):
+            nx = x + dx[i]
+            ny = y + dy[i]
+            if 0 <= nx < n and 0 <= ny < m and visited[nx][ny] == -1:
+                if data[nx][ny] == 0:
+                    visited[nx][ny] = 0
+                    continue
+                if data[nx][ny] == 1:
+                    visited[nx][ny] = visited[x][y] + 1
+                    q.append((nx, ny))
+                    
+for i in range(n):
+    for j in range(m):
+        if data[i][j] == 2 and visited[i][j] == -1:
+            bfs(i, j)
+            
+for i in range(n):
+    for j in range(m):
+        if data[i][j] == 0:
+            print(0, end=' ')
+        else:
+            print(visited[i][j], end=' ')
+    print()
+        

--- a/HeoWonIl/winter_2/4485.py
+++ b/HeoWonIl/winter_2/4485.py
@@ -1,0 +1,35 @@
+from collections import deque
+
+dx = [-1, 1, 0, 0]
+dy = [0, 0, 1, -1]
+
+def bfs(a, b):
+    q = deque()
+    q.append((a, b))
+    cost[a][b] = graph[a][b]
+    
+    while q:
+        x, y = q.popleft()
+        for i in range(4):
+            nx = x + dx[i]
+            ny = y + dy[i]
+            if 0 <= nx < n and 0 <= ny < n:
+                if cost[nx][ny] > cost[x][y] + graph[nx][ny]:
+                 cost[nx][ny] = cost[x][y] + graph[nx][ny]
+                 q.append((nx, ny))
+    
+    return cost[n - 1][n - 1]
+    
+cnt = 1
+while True:
+    n = int(input())
+    if n == 0:
+        break
+        
+    graph = []
+    cost = [[10e9] * n for _ in range(n)]
+    for _ in range(n):
+        graph.append(list(map(int, input().split())))
+    ans = bfs(0, 0)
+    print(f'Problem {cnt}: {ans}')
+    cnt += 1


### PR DESCRIPTION
## 14940 - 쉬운최단거리<br>

### :thinking: 접근 방법
- [x] 다른 사람의 코드를 참고하였다.
- [ ] 문제 풀이 방식이 전혀 떠오르지 않았다.

별도의 방문 그래프를 생성한 후, bfs를 통해 방문 그래프에 이전 노드의 값을 누적하여 다음 노드에 대입하는 방식으로 풀어야 겠다고 생각했다.

### :pencil2: 구현

```python
if data[i][j] == 2 and visited[i][j] == -1:
  bfs(i, j)
```
'방문하지 않은' '시작점' 에서 bfs 탐색을 시작한다. 

### :heavy_check_mark: 배운점

```python
if data[nx][ny] == 0:
  visited[nx][ny] = 0
  continue
```

갈 수 없는 땅의 경우 방문그래프의 해당정점을 0으로 초기화하여 방문 표시를 별도로 해준다. 이를 통해, '방문했음'과 '원래 갈 수 없음'을 동시에 표현이 가능하다.

## 13549 - 숨바꼭질 3<br>

### :thinking: 접근 방법
- [x] 다른 사람의 코드를 참고하였다.
- [x] 문제 풀이 방식이 전혀 떠오르지 않았다.

### :pencil2: 구현

```python
if 0 < cur_n * 2 < MAX_DIS and visited[cur_n * 2] == -1:
 visited[cur_n * 2] = visited[cur_n]
...
if 0 <= cur_n - 1 < MAX_DIS and visited[cur_n - 1] == -1:
  visited[cur_n - 1] = visited[cur_n] + 1
...
```
일반적인 2차원 bfs 탐색과 같이 방문 그래프를 두어 목표지점 도달 전까지 조건을 분기하여 방문하지 않은 노드들을 탐색한 후 방문 그래프를 초기화한다.

### :heavy_check_mark: 배운점

```python
q.appendleft(cur_n * 2)
```

1차원에서도 bfs 수행이 가능하다. '0-1 bfs'를 적용하면 bfs 탐색 중 큐 삽입시 우선순위를 고려할 수 있다.

## 4485 - 초록 색 옷 입은 애가 젤다지?<br>

### :thinking: 접근 방법
- [x] 다른 사람의 코드를 참고하였다.
- [ ] 문제 풀이 방식이 전혀 떠오르지 않았다.

다익스트라 최단거리 알고리즘에 기반하여 최단거리 테이블을 갱신하는 방식으로 풀어야 겠다고 생각했다. 

### :pencil2: 구현

```python
if cost[nx][ny] > cost[x][y] + graph[nx][ny]:
  cost[nx][ny] = cost[x][y] + graph[nx][ny]
  q.append((nx, ny))
```
새로운 탐색 지점에서 이전 최단거리 테이블 값과의 대소 비교를 통해 갱신 여부를 판단한다.

### :heavy_check_mark: 배운점

처음에는 조건문 없이 `min()` 함수를 사용하여 초기화하고 무조건 `append()` 하는 방식으로 로직을 구성하였는데, 그렇게 한다면 조건이 거짓일 때도 계속하여 큐에 삽입하여 무한 루프에 빠지는 오류가 발생한다. 따라서 조건문을 명시하여 큐에 삽입하여야 한다.
